### PR TITLE
Bump minimum real-time API to 1.2.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,10 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.7
-          - 3.8
           - 3.9
           - "3.10"
           - "3.11"
+          - "3.12"
         platform:
           - ubuntu-latest
           - macos-latest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+3.1.1 (2024-05-09)
+##################
+- Bumps real-time API to support Pupillometry & Eye state in real-time.
+
 3.1.0 (2023-05-25)
 ##################
 - Adds official support for Neon modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ project_urls =
 packages = find_namespace:
 install_requires =
     click>=7.0
-    pupil-labs-realtime-api>=1.1.0
+    pupil-labs-realtime-api>=1.2.1
     pylsl>=1.12.2
     rich
     typing-extensions

--- a/src/pupil_labs/lsl_relay/relay.py
+++ b/src/pupil_labs/lsl_relay/relay.py
@@ -4,8 +4,7 @@ import uuid
 from typing import Iterable, List, NoReturn, Optional
 
 from pupil_labs.realtime_api import Device, StatusUpdateNotifier, receive_gaze_data
-from pupil_labs.realtime_api.models import Component, Event, Sensor
-from pupil_labs.realtime_api.models import GazeDataType
+from pupil_labs.realtime_api.models import Component, Event, GazeDataType, Sensor
 from pupil_labs.realtime_api.time_echo import TimeOffsetEstimator
 
 from pupil_labs.lsl_relay import outlets

--- a/src/pupil_labs/lsl_relay/relay.py
+++ b/src/pupil_labs/lsl_relay/relay.py
@@ -4,7 +4,8 @@ import uuid
 from typing import Iterable, List, NoReturn, Optional
 
 from pupil_labs.realtime_api import Device, StatusUpdateNotifier, receive_gaze_data
-from pupil_labs.realtime_api.models import Component, Event, GazeDataType, Sensor
+from pupil_labs.realtime_api.models import Component, Event, Sensor
+from pupil_labs.realtime_api.simple.models import GazeDataType
 from pupil_labs.realtime_api.time_echo import TimeOffsetEstimator
 
 from pupil_labs.lsl_relay import outlets

--- a/src/pupil_labs/lsl_relay/relay.py
+++ b/src/pupil_labs/lsl_relay/relay.py
@@ -5,7 +5,7 @@ from typing import Iterable, List, NoReturn, Optional
 
 from pupil_labs.realtime_api import Device, StatusUpdateNotifier, receive_gaze_data
 from pupil_labs.realtime_api.models import Component, Event, Sensor
-from pupil_labs.realtime_api.streaming import GazeData
+from pupil_labs.realtime_api.models import GazeDataType
 from pupil_labs.realtime_api.time_echo import TimeOffsetEstimator
 
 from pupil_labs.lsl_relay import outlets
@@ -84,7 +84,7 @@ class Relay:
                 async for gaze in receive_gaze_data(
                     self.receiver.gaze_sensor_url, run_loop=True, log_level=30
                 ):
-                    if isinstance(gaze, GazeData):
+                    if isinstance(gaze, GazeDataType):
                         await self.gaze_sample_queue.put(
                             GazeAdapter(gaze, self.receiver.clock_offset_ns)
                         )
@@ -229,7 +229,7 @@ class DataReceiver:
 
 
 class GazeAdapter:
-    def __init__(self, sample: GazeData, clock_offset_ns: int):
+    def __init__(self, sample: GazeDataType, clock_offset_ns: int):
         self.x = sample.x
         self.y = sample.y
         self.timestamp_unix_seconds = (


### PR DESCRIPTION
Bump minimum real-time API to 1.2.1 to ensure it is compatible with version 2.8.10 of the Companion App (which includes pupillometry and eye state & changed its size).